### PR TITLE
Fix path to db.go in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This project would be continuously under development for enhancement. Pull reque
 1. Postgres database
 2. Golang
 
-Remark: If you want to use other databases, please feel free to change the driver in `config/db.go`
+Remark: If you want to use other databases, please feel free to change the driver in `context/db.go`
 
 #### Usage(Without docker):
 


### PR DESCRIPTION
This line in `README.md` points to the wrong path for the db config. It caused me a few minutes of confusion.

`config/db.go` should be `context/db.go`.