### PR TITLE
remove unused log import

### DIFF
--- a/service/user_service.go
+++ b/service/user_service.go
@@ -8,7 +8,6 @@ import (
 	"github.com/jmoiron/sqlx"
 	"github.com/op/go-logging"
 	"github.com/rs/xid"
-	"log"
 )
 
 const (


### PR DESCRIPTION
Looks like it might have been inadvertently added: https://github.com/OscarYuen/go-graphql-starter/commit/583d1bf35e3a820e5000ebd2488ac0945ba93f0e